### PR TITLE
Fixed issue where trying to create a dir throws error

### DIFF
--- a/src/BackblazeAdapter.php
+++ b/src/BackblazeAdapter.php
@@ -130,7 +130,8 @@ class BackblazeAdapter extends AbstractAdapter {
     {
         return $this->getClient()->upload([
             'BucketName' => $this->bucketName,
-            'FileName' => $path
+            'FileName' => $path,
+            'Body' => ''
         ]);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I simply included the key 'Body' to the call to upload on createDir method, The key 'Body' is always expected by the upload method of the B2 client

## Motivation and context

This resolves the issue while creating a directory, an error is thrown regarding undefined index 'Body'

## How has this been tested?

Please describe in detail how you tested your changes.

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.

Fixed issue where trying to create a dir throws error, this is because the key 'Body' is always expected by the upload method