### PR TITLE
matched listContents() to Flysystem interface behaviour

### DIFF
--- a/src/BackblazeAdapter.php
+++ b/src/BackblazeAdapter.php
@@ -204,11 +204,24 @@ class BackblazeAdapter extends AbstractAdapter {
         $fileObjects = $this->getClient()->listFiles([
             'BucketName' => $this->bucketName,
         ]);
-        $result = [];
-        foreach ($fileObjects as $fileObject) {
-            $result[] = $this->getFileInfo($fileObject);
+        if ($recursive === true && $directory === '') {
+            $regex = '/^.*$/';
+        } else if ($recursive === true && $directory !== '') {
+            $regex = '/^' . preg_quote($directory) . '\/.*$/';
+        } else if ($recursive === false && $directory === '') {
+            $regex = '/^(?!.*\\/).*$/';
+        } else if ($recursive === false && $directory !== '') {
+            $regex = '/^' . preg_quote($directory) . '\/(?!.*\\/).*$/';
+        } else {
+            throw new \InvalidArgumentException();
         }
-        return $result;
+        $fileObjects = array_filter($fileObjects, function ($fileObject) use ($directory, $regex) {
+            return 1 === preg_match($regex, $fileObject->getName());
+        });
+        $normalized = array_map(function ($fileObject) {
+            return $this->getFileInfo($fileObject);
+        }, $fileObjects);
+        return array_values($normalized);
     }
 
     /**


### PR DESCRIPTION
## Motivation and context

Why is this change required? What problem does it solve?

Current behaviour = listContents() dumps all files straight from B2 SDK. This doesn't really fit too well into the [Flysystem interface](https://flysystem.thephpleague.com/api/)

New behaviour = 

- For recursive (second argument) == true and dir (first argument) == '' calls, the result is exactly the same as before
- For recursive == true and dir != '' calls, files not belonging to the specified dir is filtered out
- For non-recursive calls on root dir, files not directly belonging to root dir is removed
- For non-recursive calls on non-root dir, files not directly belonging to the dir is removed

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Downstream users depending on the current non-conforming behaviour might have to patch the code.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
- [x] My code follows the code style of this project.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
