### PR TITLE
Allow using an application key not just the master key

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,14 @@ $adapter = new BackblazeAdapter($client,$bucketName);
 
 $filesystem = new Filesystem($adapter);
 ```
-## *ApplicationKey is not supported yet, please use MasterKey only*
+## Using ApplicationKey instead of MasterKey
+If you specify only the $bucketName when creating the BackblazeAdapter, your application key must be the master key.
+However, if you specify both bucket name and bucket id, you do not need the master key and can use a single-bucket key.
+Fetch your bucket id using the [b2 command line tool](https://www.backblaze.com/b2/docs/quick_command_line.html) `b2 get-bucket <bucketName>` 
+``` php
+$client = new Client($accountId, $applicationKey);
+$adapter = new BackblazeAdapter($client, $bucketName, $bucketId);
+```
 
 
 ## Doccumentation

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.1.8",
         "league/flysystem": "~1.0",
-        "gliterd/backblaze-b2": "*",
+        "gliterd/backblaze-b2": ">=1.5.0",
         "psr/http-message-implementation": "*",
         "mikey179/vfsStream": "*"
     },

--- a/src/BackblazeAdapter.php
+++ b/src/BackblazeAdapter.php
@@ -16,10 +16,13 @@ class BackblazeAdapter extends AbstractAdapter
 
     protected $bucketName;
 
-    public function __construct(Client $client, $bucketName)
+    protected $bucketId;
+
+    public function __construct(Client $client, $bucketName, $bucketId = null)
     {
         $this->client = $client;
         $this->bucketName = $bucketName;
+        $this->bucketId = $bucketId;
     }
 
     /**
@@ -27,7 +30,7 @@ class BackblazeAdapter extends AbstractAdapter
      */
     public function has($path)
     {
-        return $this->getClient()->fileExists(['FileName' => $path, 'BucketName' => $this->bucketName]);
+        return $this->getClient()->fileExists(['FileName' => $path, 'BucketId' => $this->bucketId, 'BucketName' => $this->bucketName]);
     }
 
     /**
@@ -36,6 +39,7 @@ class BackblazeAdapter extends AbstractAdapter
     public function write($path, $contents, Config $config)
     {
         $file = $this->getClient()->upload([
+            'BucketId'   => $this->bucketId,
             'BucketName' => $this->bucketName,
             'FileName'   => $path,
             'Body'       => $contents,
@@ -50,6 +54,7 @@ class BackblazeAdapter extends AbstractAdapter
     public function writeStream($path, $resource, Config $config)
     {
         $file = $this->getClient()->upload([
+            'BucketId'   => $this->bucketId,
             'BucketName' => $this->bucketName,
             'FileName'   => $path,
             'Body'       => $resource,
@@ -64,6 +69,7 @@ class BackblazeAdapter extends AbstractAdapter
     public function update($path, $contents, Config $config)
     {
         $file = $this->getClient()->upload([
+            'BucketId'   => $this->bucketId,
             'BucketName' => $this->bucketName,
             'FileName'   => $path,
             'Body'       => $contents,
@@ -78,6 +84,7 @@ class BackblazeAdapter extends AbstractAdapter
     public function updateStream($path, $resource, Config $config)
     {
         $file = $this->getClient()->upload([
+            'BucketId'   => $this->bucketId,
             'BucketName' => $this->bucketName,
             'FileName'   => $path,
             'Body'       => $resource,
@@ -92,6 +99,7 @@ class BackblazeAdapter extends AbstractAdapter
     public function read($path)
     {
         $file = $this->getClient()->getFile([
+            'BucketId'   => $this->bucketId,
             'BucketName' => $this->bucketName,
             'FileName'   => $path,
         ]);
@@ -109,6 +117,7 @@ class BackblazeAdapter extends AbstractAdapter
     {
         $stream = Psr7\stream_for();
         $download = $this->getClient()->download([
+            'BucketId'   => $this->bucketId,
             'BucketName' => $this->bucketName,
             'FileName'   => $path,
             'SaveAs'     => $stream,
@@ -138,6 +147,7 @@ class BackblazeAdapter extends AbstractAdapter
     public function copy($path, $newPath)
     {
         return $this->getClient()->upload([
+            'BucketId'   => $this->bucketId,
             'BucketName' => $this->bucketName,
             'FileName'   => $newPath,
             'Body'       => @file_get_contents($path),
@@ -149,7 +159,7 @@ class BackblazeAdapter extends AbstractAdapter
      */
     public function delete($path)
     {
-        return $this->getClient()->deleteFile(['FileName' => $path, 'BucketName' => $this->bucketName]);
+        return $this->getClient()->deleteFile(['FileName' => $path, 'BucketId' => $this->bucketId, 'BucketName' => $this->bucketName]);
     }
 
     /**
@@ -157,7 +167,7 @@ class BackblazeAdapter extends AbstractAdapter
      */
     public function deleteDir($path)
     {
-        return $this->getClient()->deleteFile(['FileName' => $path, 'BucketName' => $this->bucketName]);
+        return $this->getClient()->deleteFile(['FileName' => $path, 'BucketId' => $this->bucketId, 'BucketName' => $this->bucketName]);
     }
 
     /**
@@ -166,6 +176,7 @@ class BackblazeAdapter extends AbstractAdapter
     public function createDir($path, Config $config)
     {
         return $this->getClient()->upload([
+            'BucketId'   => $this->bucketId,
             'BucketName' => $this->bucketName,
             'FileName'   => $path,
             'Body'       => '',
@@ -193,7 +204,7 @@ class BackblazeAdapter extends AbstractAdapter
      */
     public function getSize($path)
     {
-        $file = $this->getClient()->getFile(['FileName' => $path, 'BucketName' => $this->bucketName]);
+        $file = $this->getClient()->getFile(['FileName' => $path, 'BucketId' => $this->bucketId, 'BucketName' => $this->bucketName]);
 
         return $this->getFileInfo($file);
     }
@@ -203,7 +214,7 @@ class BackblazeAdapter extends AbstractAdapter
      */
     public function getTimestamp($path)
     {
-        $file = $this->getClient()->getFile(['FileName' => $path, 'BucketName' => $this->bucketName]);
+        $file = $this->getClient()->getFile(['FileName' => $path, 'BucketId' => $this->bucketId, 'BucketName' => $this->bucketName]);
 
         return $this->getFileInfo($file);
     }
@@ -222,6 +233,7 @@ class BackblazeAdapter extends AbstractAdapter
     public function listContents($directory = '', $recursive = false)
     {
         $fileObjects = $this->getClient()->listFiles([
+            'BucketId'   => $this->bucketId,
             'BucketName' => $this->bucketName,
         ]);
         if ($recursive === true && $directory === '') {
@@ -235,7 +247,7 @@ class BackblazeAdapter extends AbstractAdapter
         } else {
             throw new \InvalidArgumentException();
         }
-        $fileObjects = array_filter($fileObjects, function ($fileObject) use ($directory, $regex) {
+        $fileObjects = array_filter($fileObjects, function ($fileObject) use ($regex) {
             return 1 === preg_match($regex, $fileObject->getName());
         });
         $normalized = array_map(function ($fileObject) {

--- a/tests/BackblazeAdapterTests.php
+++ b/tests/BackblazeAdapterTests.php
@@ -37,7 +37,7 @@ class BackblazeAdapterTests extends PHPUnit_Framework_TestCase
      */
     public function testHas($adapter, $mock)
     {
-        $mock->fileExists(['BucketName' => 'my_bucket', 'FileName' => 'something'])->willReturn(true);
+        $mock->fileExists(['BucketId' => null, 'BucketName' => 'my_bucket', 'FileName' => 'something'])->willReturn(true);
         $result = $adapter->has('something');
         $this->assertTrue($result);
     }
@@ -47,7 +47,7 @@ class BackblazeAdapterTests extends PHPUnit_Framework_TestCase
      */
     public function testWrite($adapter, $mock)
     {
-        $mock->upload(['BucketName' => 'my_bucket', 'FileName' => 'something', 'Body' => 'contents'])->willReturn(new File('something', '', '', '', ''), false);
+        $mock->upload(['BucketId' => null, 'BucketName' => 'my_bucket', 'FileName' => 'something', 'Body' => 'contents'])->willReturn(new File('something', '', '', '', ''), false);
         $result = $adapter->write('something', 'contents', new Config());
         $this->assertInternalType('array', $result);
         $this->assertArrayHasKey('type', $result);
@@ -59,7 +59,7 @@ class BackblazeAdapterTests extends PHPUnit_Framework_TestCase
      */
     public function testWriteStream($adapter, $mock)
     {
-        $mock->upload(['BucketName' => 'my_bucket', 'FileName' => 'something', 'Body' => 'contents'])->willReturn(new File('something', '', '', '', ''), false);
+        $mock->upload(['BucketId' => null, 'BucketName' => 'my_bucket', 'FileName' => 'something', 'Body' => 'contents'])->willReturn(new File('something', '', '', '', ''), false);
         $result = $adapter->writeStream('something', 'contents', new Config());
         $this->assertInternalType('array', $result);
         $this->assertArrayHasKey('type', $result);
@@ -71,7 +71,7 @@ class BackblazeAdapterTests extends PHPUnit_Framework_TestCase
      */
     public function testUpdate($adapter, $mock)
     {
-        $mock->upload(['BucketName' => 'my_bucket', 'FileName' => 'something', 'Body' => 'contents'])->willReturn(new File('something', '', '', '', ''), false);
+        $mock->upload(['BucketId' => null, 'BucketName' => 'my_bucket', 'FileName' => 'something', 'Body' => 'contents'])->willReturn(new File('something', '', '', '', ''), false);
         $result = $adapter->update('something', 'contents', new Config());
         $this->assertInternalType('array', $result);
         $this->assertArrayHasKey('type', $result);
@@ -83,7 +83,7 @@ class BackblazeAdapterTests extends PHPUnit_Framework_TestCase
      */
     public function testUpdateStream($adapter, $mock)
     {
-        $mock->upload(['BucketName' => 'my_bucket', 'FileName' => 'something', 'Body' => 'contents'])->willReturn(new File('something', '', '', '', ''), false);
+        $mock->upload(['BucketId' => null, 'BucketName' => 'my_bucket', 'FileName' => 'something', 'Body' => 'contents'])->willReturn(new File('something', '', '', '', ''), false);
         $result = $adapter->updateStream('something', 'contents', new Config());
         $this->assertInternalType('array', $result);
         $this->assertArrayHasKey('type', $result);
@@ -96,7 +96,7 @@ class BackblazeAdapterTests extends PHPUnit_Framework_TestCase
     public function testRead($adapter, $mock)
     {
         $file = new File('something', 'something4', '', '', '', '', 'my_bucket');
-        $mock->getFile(['BucketName' => 'my_bucket', 'FileName' => 'something'])->willReturn($file, false);
+        $mock->getFile(['BucketId' => null, 'BucketName' => 'my_bucket', 'FileName' => 'something'])->willReturn($file, false);
         $mock->download(['FileId' => 'something'])->willReturn($file, false);
         $result = $adapter->read('something');
         $this->assertEquals(['contents' => $file], $result);
@@ -148,7 +148,7 @@ class BackblazeAdapterTests extends PHPUnit_Framework_TestCase
     public function testCopy($adapter, $mock)
     {
         $this->fileSetUp();
-        $mock->upload(['BucketName' => 'my_bucket', 'FileName' => 'something_new', 'Body' => ''])->willReturn(new File('something_new', '', '', '', ''), false);
+        $mock->upload(['BucketId' => null, 'BucketName' => 'my_bucket', 'FileName' => 'something_new', 'Body' => ''])->willReturn(new File('something_new', '', '', '', ''), false);
         $result = $adapter->copy($this->file_mock->url(), 'something_new');
         $this->assertObjectHasAttribute('id', $result, 'something_new');
     }
@@ -158,7 +158,7 @@ class BackblazeAdapterTests extends PHPUnit_Framework_TestCase
      */
     public function testListContents($adapter, $mock)
     {
-        $mock->listFiles(['BucketName' => 'my_bucket'])->willReturn([new File('random_id', 'file1.txt'), new File('random_id', 'some_folder/file2.txt'), new File('random_id', 'some_folder/another_folder/file3.txt')]);
+        $mock->listFiles(['BucketId' => null, 'BucketName' => 'my_bucket'])->willReturn([new File('random_id', 'file1.txt'), new File('random_id', 'some_folder/file2.txt'), new File('random_id', 'some_folder/another_folder/file3.txt')]);
         $normalized_files = [
             [
                 'type'      => 'file',


### PR DESCRIPTION
## Description
Not everyone wishes to integrate with Backblaze using the master key. It is better for security reasons for each application to use its own application key, which gives it access to a single bucket.

However, due to complexities in the Backblaze API, this project does not yet support single-bucket application keys. Some Backblaze API calls require the bucket id, and some require a bucket name. The current workaround involves using the list_buckets command to fetch a bucket id from its name, which requires the master key.

This PR seeks to remedy this by passing both bucket id and name to the backblaze-b2 client. This requires some further changes to that project (see https://github.com/gliterd/backblaze-b2/pull/62 which must be merged before this).

All a developer needs to do is configure their flysystem with both the bucket id and name, so the system no longer needs to look them up, therefore not needing access to list_buckets, therefore not needing the master key.

## Motivation and context
As described above - allowing each application to have a separate bucket for security reasons.

## How has this been tested?
I have loaded these changes, plus gliterd/laravel-backblaze-b2 into my laravel project and tested put, get, exists, allFiles, delete.

## Screenshots (if appropriate)
n/a

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
- [x] My code follows the code style of this project.

> If you're unsure about any of these, don't hesitate to ask. We're here to help!

Please advise whether you wish for further tests.