### PR TITLE
Copy using the SDK's copy method

### DIFF
--- a/src/BackblazeAdapter.php
+++ b/src/BackblazeAdapter.php
@@ -146,11 +146,11 @@ class BackblazeAdapter extends AbstractAdapter
      */
     public function copy($path, $newPath)
     {
-        return $this->getClient()->upload([
+        return $this->getClient()->copy([
             'BucketId'   => $this->bucketId,
             'BucketName' => $this->bucketName,
-            'FileName'   => $newPath,
-            'Body'       => @file_get_contents($path),
+            'FileName'   => $path,
+            'SaveAs'     => $newPath,
         ]);
     }
 

--- a/tests/BackblazeAdapterTests.php
+++ b/tests/BackblazeAdapterTests.php
@@ -148,9 +148,9 @@ class BackblazeAdapterTests extends PHPUnit_Framework_TestCase
     public function testCopy($adapter, $mock)
     {
         $this->fileSetUp();
-        $mock->upload(['BucketId' => null, 'BucketName' => 'my_bucket', 'FileName' => 'something_new', 'Body' => ''])->willReturn(new File('something_new', '', '', '', ''), false);
-        $result = $adapter->copy($this->file_mock->url(), 'something_new');
-        $this->assertObjectHasAttribute('id', $result, 'something_new');
+        $mock->copy(['BucketId' => null, 'BucketName' => 'my_bucket', 'FileName' => 'something_old', 'SaveAs' => 'something_new'])->willReturn(new File('random_id', 'something_new', '', '', ''), false);
+        $result = $adapter->copy('something_old', 'something_new');
+        $this->assertObjectHasAttribute('id', $result);
     }
 
     /**


### PR DESCRIPTION
## Description

Changes the copy method to use the SDK copy method, which uses the Backblaze API [b2_copy_file](https://www.backblaze.com/b2/docs/b2_copy_file.html) operation.

## Motivation and context

The SDK has a copy method to perform tue copy through the `b2_copy_file` operation from the Backblaze API.

The current implementation cannot copy a file from one location to another in Backblaze.

## How has this been tested?

I have loaded these changes, plus gliterd/laravel-backblaze-b2 into my Laravel project and tested.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
- [x] My code follows the code style of this project.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
